### PR TITLE
TBC Stat fix

### DIFF
--- a/LocaleExtra/enUS.lua
+++ b/LocaleExtra/enUS.lua
@@ -223,7 +223,8 @@ if Addon.expansionLevel <= Addon.expansions.tbc then
     {INPUT = "^Restores ([%d,]+) health every 5 sec%.$"})
   
   Addon:AddExtraStatCapture("Mana Regeneration",
-    {INPUT = "^%+([%d,]+) mana every 5 sec%.$"})
+    {INPUT = "^%+([%d,]+) mana every 5 sec%.$"},
+    {INPUT = "^%+([%d,]+) Mana Per 5 sec%.$"})
 end
 
 if Addon.isSoD or Addon.isTBC then

--- a/LocaleExtra/enUS.lua
+++ b/LocaleExtra/enUS.lua
@@ -177,12 +177,14 @@ if Addon.expansionLevel <= Addon.expansions.tbc then
     {INPUT = "^%+([%d,]+) Block Rating$"})
   
   Addon:AddExtraStatCapture("Healing",
+    {INPUT = "^%+([%d,]+) Healing$"},
     {INPUT = "^%+([%d,]+) Healing Spells and %+[%d,]+ Damage Spells$"},
     {INPUT = "^Increases your spell damage by up to [%d,]+ and your healing by up to ([%d,]+)%.$"})
   
   Addon:AddExtraStatCapture("Spell Power",
     {INPUT = "^Increases damage and healing done by magical spells and effects by up to ([%d,]+)%.$"},
-    {INPUT = "^%+([%d,]+) Damage and Healing Spells$"})
+    {INPUT = "^%+([%d,]+) Damage and Healing Spells$"},
+    {INPUT = "^%+([%d,]+) Spell Damage and Healing$"})
   
   Addon:AddExtraStatCapture("Arcane Damage",
     {INPUT = "^Increases damage done by Arcane spells and effects by up to ([%d,]+)%.$"})


### PR DESCRIPTION
Added 2 TBC stats to enUS locale that weren't being parsed:
- +## Healing
- +## Spell Damage and Healing

Example: +24 Spell Damage and Healing wasn't working, now works.
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/a683cd1f-943b-4394-a986-5a0f26f5a0a1" />
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/85f03b6b-bae4-4557-85e6-fd8d4618b3f3" />

